### PR TITLE
Add option to specify JDK_ARCH

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -12,11 +12,15 @@ if(
                       "JAVA_HOME to point to the location of the JDK.")
 endif()
 
-# Check if the variable JDK_ARCH exists and if not set it to 'amd64' by default
+# Check if the local or environment variable JDK_ARCH exists and if not set it to 'amd64' by default
 if(
     (NOT (DEFINED JDK_ARCH))
   )
-  set( JDK_ARCH amd64 )
+  if( DEFINED ENV{JDK_ARCH} )
+    set( JDK_ARCH $ENV{JDK_ARCH} )
+  else()
+    set( JDK_ARCH amd64 )
+  endif()
 endif()
 
 set(java_module_host_manager_sources

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -12,6 +12,13 @@ if(
                       "JAVA_HOME to point to the location of the JDK.")
 endif()
 
+# Check if the environment variable JDK_ARCH exists and if not set it to 'amd64' by default
+if(
+    (NOT (DEFINED ENV{JDK_ARCH}))
+  )
+  set( ENV{JDK_ARCH} amd64 )
+endif()
+
 set(java_module_host_manager_sources
     ./src/java_module_host_manager.c
 )
@@ -75,10 +82,10 @@ elseif(LINUX)
         $ENV{JAVA_HOME}/include/linux
     )
     set(java_link_dirs
-        $ENV{JAVA_HOME}/jre/lib/amd64/server
+        $ENV{JAVA_HOME}/jre/lib/$ENV{JDK_ARCH}/server
     )
     set(java_libs
-        $ENV{JAVA_HOME}/jre/lib/amd64/server/libjvm.so
+        $ENV{JAVA_HOME}/jre/lib/$ENV{JDK_ARCH}/server/libjvm.so
     )
 endif()
 

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -12,11 +12,11 @@ if(
                       "JAVA_HOME to point to the location of the JDK.")
 endif()
 
-# Check if the environment variable JDK_ARCH exists and if not set it to 'amd64' by default
+# Check if the variable JDK_ARCH exists and if not set it to 'amd64' by default
 if(
-    (NOT (DEFINED ENV{JDK_ARCH}))
+    (NOT (DEFINED JDK_ARCH))
   )
-  set( ENV{JDK_ARCH} amd64 )
+  set( JDK_ARCH amd64 )
 endif()
 
 set(java_module_host_manager_sources
@@ -82,10 +82,10 @@ elseif(LINUX)
         $ENV{JAVA_HOME}/include/linux
     )
     set(java_link_dirs
-        $ENV{JAVA_HOME}/jre/lib/$ENV{JDK_ARCH}/server
+        $ENV{JAVA_HOME}/jre/lib/${JDK_ARCH}/server
     )
     set(java_libs
-        $ENV{JAVA_HOME}/jre/lib/$ENV{JDK_ARCH}/server/libjvm.so
+        $ENV{JAVA_HOME}/jre/lib/${JDK_ARCH}/server/libjvm.so
     )
 endif()
 

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 2.8.11)
 #this is CMakeLists for java binding
 
-# Check if the environment variables NODE_INCLUDE and NODE_LIB exist
+# Check if the environment variable JAVA_HOME exists
 if(
     (NOT (DEFINED ENV{JAVA_HOME}))
   )

--- a/doc/java_how_to.md
+++ b/doc/java_how_to.md
@@ -129,6 +129,8 @@ If using cmake and msbuild or make:
   - Create a new directory from the root of the repository called 'build'
   - ```cd build```
   - ```cmake -Denable_java_binding=ON ../```
+  - If your JDK arch is different to ***amd64*** (e.g. i386) you can specify an arch using the ```JDK_ARCH``` variable in your ```cmake``` command:
+  - ```-DJDK_ARCH={jdk_arch}```
   - If using msbuild on Windows: ```msbuild /m /p:Configuration=[Debug | Release] /p:Platform=Win32 azure_iot_gateway_sdk.sln```
   - If using make on Linux: ```make```
   


### PR DESCRIPTION
Currently the JDK arch is hard-coded to 'amd64' which limits compatibility. This patch adds an option to specify JDK_ARCH using an environment variable and if not set it defaults to 'amd64'.