### PR TITLE
Ensure static libs cannot be built shared

### DIFF
--- a/bindings/dotnet/CMakeLists.txt
+++ b/bindings/dotnet/CMakeLists.txt
@@ -45,7 +45,7 @@ add_library(dotnet MODULE ${dotnet_sources}  ${dotnet_headers})
 target_link_libraries(dotnet gateway mscoree)
 
 #this builds the dotnet static library
-add_library(dotnet_static  ${dotnet_static_sources} ${dotnet_static_headers})
+add_library(dotnet_static STATIC ${dotnet_static_sources} ${dotnet_static_headers})
 target_compile_definitions(dotnet_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(dotnet_static gateway mscoree)
 
@@ -54,7 +54,7 @@ add_library(dotnet_hl MODULE ${dotnet_hl_sources} ${dotnet_hl_headers})
 target_link_libraries(dotnet_hl dotnet_static gateway mscoree)
 
 #this builds the dotnet static library (by default it uses dotnet module linked statically)
-add_library(dotnet_hl_static ${dotnet_hl_static_sources} ${dotnet_hl_static_headers})
+add_library(dotnet_hl_static STATIC ${dotnet_hl_static_sources} ${dotnet_hl_static_headers})
 target_compile_definitions(dotnet_hl_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(dotnet_hl_static dotnet_static gateway mscoree)
 

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -94,7 +94,7 @@ add_library(java_module_host MODULE ${java_module_host_headers} ${java_module_ho
 target_link_libraries(java_module_host ${LIBS})
 
 #this build the java_module_host static library
-add_library(java_module_host_static ${java_module_host_static_headers} ${java_module_host_static_sources})
+add_library(java_module_host_static STATIC ${java_module_host_static_headers} ${java_module_host_static_sources})
 target_compile_definitions(java_module_host_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(java_module_host_static ${LIBS})
 
@@ -103,7 +103,7 @@ add_library(java_module_host_hl MODULE ${java_module_host_hl_headers} ${java_mod
 target_link_libraries(java_module_host_hl java_module_host_static ${LIBS})
 
 #this builds the java_module_host_hl static library (by default it uses the java_module_host linked statically)
-add_library(java_module_host_hl_static ${java_module_host_hl_static_headers} ${java_module_host_hl_static_sources})
+add_library(java_module_host_hl_static STATIC ${java_module_host_hl_static_headers} ${java_module_host_hl_static_sources})
 target_compile_definitions(java_module_host_hl_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(java_module_host_hl_static java_module_host_static ${LIBS})
 

--- a/bindings/nodejs/CMakeLists.txt
+++ b/bindings/nodejs/CMakeLists.txt
@@ -127,7 +127,7 @@ add_pic_flag(nodejs_binding)
 target_include_directories(nodejs_binding PUBLIC $ENV{NODE_INCLUDE})
 
 # build nodejs_binding as a static library
-add_library(nodejs_binding_static ${nodejs_static_sources} ${nodejs_static_headers})
+add_library(nodejs_binding_static STATIC ${nodejs_static_sources} ${nodejs_static_headers})
 target_compile_definitions(nodejs_binding_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(nodejs_binding_static ${LIBS})
 linkSharedUtil(nodejs_binding_static)
@@ -142,7 +142,7 @@ add_pic_flag(nodejs_binding_hl)
 target_include_directories(nodejs_binding_hl PUBLIC $ENV{NODE_INCLUDE})
 
 #this builds the nodejs_binding_hl static library
-add_library(nodejs_binding_hl_static ${nodejs_hl_static_sources} ${nodejs_hl_static_headers})
+add_library(nodejs_binding_hl_static STATIC ${nodejs_hl_static_sources} ${nodejs_hl_static_headers})
 target_compile_definitions(nodejs_binding_hl_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(nodejs_binding_hl_static nodejs_binding_static ${LIBS})
 linkSharedUtil(nodejs_binding_hl_static)

--- a/modules/ble/CMakeLists.txt
+++ b/modules/ble/CMakeLists.txt
@@ -106,7 +106,7 @@ target_link_libraries(ble ${LIBS})
 linkSharedUtil(ble)
 
 # build ble as a static library
-add_library(ble_static ${ble_static_sources} ${ble_static_headers})
+add_library(ble_static STATIC ${ble_static_sources} ${ble_static_headers})
 target_compile_definitions(ble_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(ble_static ${LIBS} iothub_service_client)
 linkSharedUtil(ble_static)
@@ -117,7 +117,7 @@ target_link_libraries(ble_hl ble_static ${LIBS})
 linkSharedUtil(ble_hl)
 
 # build ble HL as a static library
-add_library(ble_hl_static ${ble_hl_static_sources} ${ble_hl_static_headers})
+add_library(ble_hl_static STATIC ${ble_hl_static_sources} ${ble_hl_static_headers})
 target_compile_definitions(ble_hl_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(ble_hl_static ble_static ${LIBS} iothub_service_client)
 linkSharedUtil(ble_hl_static)

--- a/modules/hello_world/CMakeLists.txt
+++ b/modules/hello_world/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(hello_world MODULE ${hello_world_sources}  ${hello_world_headers})
 target_link_libraries(hello_world gateway)
 
 #this builds the hello_world static library
-add_library(hello_world_static  ${hello_world_static_sources} ${hello_world_static_headers})
+add_library(hello_world_static STATIC ${hello_world_static_sources} ${hello_world_static_headers})
 target_compile_definitions(hello_world_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(hello_world_static gateway)
 
@@ -53,7 +53,7 @@ add_library(hello_world_hl MODULE ${hello_world_hl_sources} ${hello_world_hl_hea
 target_link_libraries(hello_world_hl hello_world_static gateway)
 
 #this builds the hello_world static library (by default it uses hello_world module linked statically)
-add_library(hello_world_hl_static ${hello_world_hl_static_sources} ${hello_world_hl_static_headers})
+add_library(hello_world_hl_static STATIC ${hello_world_hl_static_sources} ${hello_world_hl_static_headers})
 target_compile_definitions(hello_world_hl_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(hello_world_hl_static hello_world_static gateway)
 

--- a/modules/identitymap/CMakeLists.txt
+++ b/modules/identitymap/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(identity_map MODULE ${identity_map_sources}  ${identity_map_headers}
 target_link_libraries(identity_map gateway)
 
 #this builds the identity_map static library
-add_library(identity_map_static  ${identity_map_static_sources} ${identity_map_static_headers})
+add_library(identity_map_static STATIC ${identity_map_static_sources} ${identity_map_static_headers})
 target_compile_definitions(identity_map_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(identity_map_static gateway)
 
@@ -53,7 +53,7 @@ add_library(identity_map_hl MODULE ${identity_map_hl_sources} ${identity_map_hl_
 target_link_libraries(identity_map_hl identity_map_static gateway)
 
 #this builds the identity_map hl static library (by default it uses identity_map module linked statically)
-add_library(identity_map_hl_static ${identity_map_hl_static_sources} ${identity_map_hl_static_headers})
+add_library(identity_map_hl_static STATIC ${identity_map_hl_static_sources} ${identity_map_hl_static_headers})
 target_compile_definitions(identity_map_hl_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(identity_map_hl_static identity_map_static gateway)
 

--- a/modules/iothubhttp/CMakeLists.txt
+++ b/modules/iothubhttp/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries(iothubhttp
 )
 
 #this builds the IoTHubHTTP static library
-add_library(iothubhttp_static
+add_library(iothubhttp_static STATIC
     ${iothubhttp_sources}
     ${iothubhttp_headers}
 )
@@ -57,7 +57,7 @@ target_link_libraries(iothubhttp_hl
 )
 
 #this builds the IoTHubHTTP_HL static library (by default it uses IoTHub Module linked statically)
-add_library(iothubhttp_hl_static
+add_library(iothubhttp_hl_static STATIC
     ${iothubhttp_hl_sources}
     ${iothubhttp_hl_headers}
 )

--- a/modules/logger/CMakeLists.txt
+++ b/modules/logger/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(logger MODULE ${logger_sources}  ${logger_headers})
 target_link_libraries(logger gateway)
 
 #this builds the Logger static library
-add_library(logger_static  ${logger_static_sources} ${logger_static_headers})
+add_library(logger_static STATIC ${logger_static_sources} ${logger_static_headers})
 target_compile_definitions(logger_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(logger_static gateway)
 
@@ -53,7 +53,7 @@ add_library(logger_hl MODULE ${logger_hl_sources} ${logger_hl_headers})
 target_link_libraries(logger_hl logger_static gateway)
 
 #this builds the Logger_HL static library (by default it uses Logger linked statically)
-add_library(logger_hl_static ${logger_hl_static_sources} ${logger_hl_static_headers})
+add_library(logger_hl_static STATIC ${logger_hl_static_sources} ${logger_hl_static_headers})
 target_compile_definitions(logger_hl_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(logger_hl_static logger_static gateway)
 

--- a/modules/simulated_device/CMakeLists.txt
+++ b/modules/simulated_device/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(simulated_device MODULE ${simulated_device_sources}  ${simulated_dev
 target_link_libraries(simulated_device gateway)
 
 #this builds the simulated_device static library
-add_library(simulated_device_static  ${simulated_device_static_sources} ${simulated_device_static_headers})
+add_library(simulated_device_static STATIC ${simulated_device_static_sources} ${simulated_device_static_headers})
 target_compile_definitions(simulated_device_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(simulated_device_static gateway)
 
@@ -53,7 +53,7 @@ add_library(simulated_device_hl MODULE ${simulated_device_hl_sources} ${simulate
 target_link_libraries(simulated_device_hl simulated_device_static gateway)
 
 #this builds the simulated_device static library (by default it uses simulated_device module linked statically)
-add_library(simulated_device_hl_static ${simulated_device_hl_static_sources} ${simulated_device_hl_static_headers})
+add_library(simulated_device_hl_static STATIC ${simulated_device_hl_static_sources} ${simulated_device_hl_static_headers})
 target_compile_definitions(simulated_device_hl_static PRIVATE BUILD_MODULE_TYPE_STATIC)
 target_link_libraries(simulated_device_hl_static simulated_device_static gateway)
 


### PR DESCRIPTION
Currently if the 'BUILD_SHARED_LIBS' flag is set to 'ON' static libraries are built as shared. As we are building both shared and static libraries for modules and bindings it makes sense to force library type so they can't be overridden.