### PR TITLE
User can specific simulate sample's message sending period

### DIFF
--- a/modules/simulated_device/src/simulated_device.c
+++ b/modules/simulated_device/src/simulated_device.c
@@ -249,6 +249,7 @@ static void * SimulatedDevice_ParseConfigurationFromJson(const char* configurati
                             config.messagePeriod = period;
                             result = malloc(sizeof(SIMULATEDDEVICE_CONFIG));
                             if (result == NULL) {
+                                free(config.macAddress);
                                 LogError("allocation of configuration failed");
                             }
                             else
@@ -269,7 +270,9 @@ void SimulatedDevice_FreeConfiguration(void * configuration)
 {
 	if (configuration != NULL)
 	{
-		free(configuration);
+        SIMULATEDDEVICE_CONFIG * config = (SIMULATEDDEVICE_CONFIG *)configuration;
+        free(config->macAddress);
+        free(config);
 	}
 }
 

--- a/samples/simulated_device_cloud_upload/src/simulated_device_cloud_upload_lin.json
+++ b/samples/simulated_device_cloud_upload/src/simulated_device_cloud_upload_lin.json
@@ -44,7 +44,8 @@
         }
       },
       "args": {
-        "macAddress": "01:01:01:01:01:01"
+        "macAddress": "01:01:01:01:01:01",
+        "messagePeriod": 2000
       }
     },
     {
@@ -56,7 +57,8 @@
         }
       },
       "args": {
-        "macAddress": "02:02:02:02:02:02"
+        "macAddress": "02:02:02:02:02:02",
+        "messagePeriod": 2000
       }
     },
     {

--- a/samples/simulated_device_cloud_upload/src/simulated_device_cloud_upload_win.json
+++ b/samples/simulated_device_cloud_upload/src/simulated_device_cloud_upload_win.json
@@ -44,7 +44,8 @@
         }
       },
       "args": {
-        "macAddress": "01:01:01:01:01:01"
+        "macAddress": "01:01:01:01:01:01",
+        "messagePeriod": 2000
       }
     },
     {
@@ -56,7 +57,8 @@
         }
       },
       "args": {
-        "macAddress": "02:02:02:02:02:02"
+        "macAddress": "02:02:02:02:02:02",
+        "messagePeriod": 2000
       }
     },
     {


### PR DESCRIPTION
The simulate sample always send a message every 10 seconds in currect time.

It is different with the BLE sample, which will make the "simlate" sample not simulate the BLE sample's behavior.

@darobs I change the pull request to develop branch. Besides this, I resolve your comments in [PullRequest 61](https://github.com/Azure/azure-iot-gateway-sdk/pull/61), you can view the incremental changes in the [second commit](https://github.com/Azure/azure-iot-gateway-sdk/commit/7b539056e99ce14325424c1b0c345723bb832058) 