### PR TITLE
Allow create Field Gateway inside c# process

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,6 +1,6 @@
 The Azure IoT Gateway SDK shares the same [contribution guidelines](https://github.com/Azure/azure-iot-sdks/blob/master/CONTRIBUTING.md) as
 the other Azure IoT SDKs. The gateway SDK team also monitors our [GitHub issues](https://github.com/Azure/azure-iot-gateway-sdk/issues)
-section and Stack Overflow, especially the [iot-gateway-sdk](http://stackoverflow.com/questions/tagged/iot-gateway-sdk) tag.
+section and Stack Overflow, especially the [azure-iot-gateway-sdk](http://stackoverflow.com/questions/tagged/azure-iot-gateway-sdk) tag.
 
 ----------
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Other people are creating modules for the gateway SDK too! See the **More inform
 a module to find out how to get it, who supports it, etc.
 >| Name          | More information                            | Targets gateway SDK version |
 >|---------------|---------------------------------------------|-----------------------------|
->| Modbus        | https://github.com/Azure/iot-gateway-modbus | 2016-11-02                  |
+>| Modbus        | https://github.com/Azure/iot-gateway-modbus | 2016-11-18                  |
 >| OPC-UA Client | https://github.com/Azure/iot-gateway-opc-ua | 2016-11-18                  |
 
 We'd love to feature your module here! See our [Contribution guidelines](Contributing.md) for 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments
 
-# Azure IoT Gateway SDK
+# [Azure IoT Gateway SDK](https://azure.microsoft.com/en-us/services/iot-hub/iot-gateway-sdk/)
 Using this SDK, developers write applications that enable gateway-connected devices to 
 communicate with Azure IoT Hub. Such applications use a collection of **modules** to aggregate 
 and transform data, process commands, or perform any number of related tasks. Modules 

--- a/bindings/dotnet/dotnet-binding/Microsoft.Azure.IoT.Gateway/Broker.cs
+++ b/bindings/dotnet/dotnet-binding/Microsoft.Azure.IoT.Gateway/Broker.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Azure.IoT.Gateway
 {
     /// <summary> Object that represents the message broker, to which messsages will be published. </summary>
-    public class Broker
+    public class Broker : IBroker
     {
         private long brokerHandle;
 

--- a/bindings/dotnet/dotnet-binding/Microsoft.Azure.IoT.Gateway/IBroker.cs
+++ b/bindings/dotnet/dotnet-binding/Microsoft.Azure.IoT.Gateway/IBroker.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.IoT.Gateway
+{
+    /// <summary> Message broker interface for unit testing. </summary>
+    public interface IBroker
+    {
+        void Publish(Message message);
+    }
+}

--- a/bindings/dotnet/dotnet-binding/Microsoft.Azure.IoT.Gateway/Microsoft.Azure.IoT.Gateway.csproj
+++ b/bindings/dotnet/dotnet-binding/Microsoft.Azure.IoT.Gateway/Microsoft.Azure.IoT.Gateway.csproj
@@ -79,6 +79,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IBroker.cs" />
     <Compile Include="IGatewayModule.cs" />
     <Compile Include="IGatewayModuleStart.cs" />
     <Compile Include="Message.cs" />

--- a/bindings/dotnet/dotnet-binding/Microsoft.Azure.IoT.Gateway/nativeDotNetHostWrapper.cs
+++ b/bindings/dotnet/dotnet-binding/Microsoft.Azure.IoT.Gateway/nativeDotNetHostWrapper.cs
@@ -15,6 +15,21 @@ namespace Microsoft.Azure.IoT.Gateway
     public class NativeDotNetHostWrapper
     {
         /// <summary>
+        /// Gateways the create from json.
+        /// </summary>
+        /// <param name="filePath">The file path.</param>
+        [DllImport(@"dotnet.dll", EntryPoint = "Module_DotNetHost_Gateway_CreateFromJson", CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr GatewayCreateFromJson([MarshalAs(UnmanagedType.LPStr)] string filePath);
+
+        /// <summary>
+        /// Gateways the destroy.
+        /// </summary>
+        /// <param name="gateway">The gateway.</param>
+        /// <returns>IntPtr.</returns>
+        [DllImport(@"dotnet.dll", EntryPoint = "Module_DotNetHost_Gateway_Destroy", CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr GatewayDestroy(IntPtr gateway);
+
+        /// <summary>
         ///      Module_DotNetHost wrapper for publishing a message.
         /// </summary>
         /// <param name="broker">Handle to the message broker.</param>

--- a/bindings/dotnet/inc/dotnet.h
+++ b/bindings/dotnet/inc/dotnet.h
@@ -5,6 +5,7 @@
 #define DOTNET_H
 
 #include "module.h"
+#include "gateway.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -21,6 +22,10 @@ typedef struct DOTNET_HOST_CONFIG_TAG
 MODULE_EXPORT const MODULE_API* Module_GetApi(MODULE_API_VERSION gateway_api_version);
 
 extern __declspec(dllexport) bool Module_DotNetHost_PublishMessage(BROKER_HANDLE broker, MODULE_HANDLE sourceModule, const unsigned char* message, int32_t size);
+
+extern __declspec(dllexport) GATEWAY_HANDLE Module_DotNetHost_Gateway_CreateFromJson(const char* file_path);
+
+extern __declspec(dllexport) void Module_DotNetHost_Gateway_Destroy(GATEWAY_HANDLE handle);
 
 #ifdef __cplusplus
 }

--- a/bindings/dotnet/src/dotnet.cpp
+++ b/bindings/dotnet/src/dotnet.cpp
@@ -8,6 +8,7 @@
 
 #include "azure_c_shared_utility/gballoc.h"
 
+#include "gateway.h"
 #include "module.h"
 #include "message.h"
 #include "azure_c_shared_utility/xlogging.h"
@@ -611,6 +612,16 @@ static void DotNet_Destroy(MODULE_HANDLE module)
         /* Codes_SRS_DOTNET_04_020: [ DotNet_Destroy shall free all resources associated with the given module.. ] */
         delete(handleData);
     }
+}
+
+MODULE_EXPORT GATEWAY_HANDLE Module_DotNetHost_Gateway_CreateFromJson(const char* file_path)
+{
+	return Gateway_CreateFromJson(file_path);
+}
+
+MODULE_EXPORT void Module_DotNetHost_Gateway_Destroy(GATEWAY_HANDLE handle)
+{
+	Gateway_Destroy(handle);
 }
 
 MODULE_EXPORT bool Module_DotNetHost_PublishMessage(BROKER_HANDLE broker, MODULE_HANDLE sourceModule, const unsigned char* message, int32_t size)


### PR DESCRIPTION
I would like to be able to create field gateway inside c# process using this syntax
this.gatewayHandle = NativeDotNetHostWrapper.GatewayCreateFromJson(GatewayConfigName);

it would allow us hosting field gateway e.g. inside windows service written in c#.