### PR TITLE
Add test for NODEJS_Create

### DIFF
--- a/bindings/nodejs/devdoc/nodejs_binding_requirements.md
+++ b/bindings/nodejs/devdoc/nodejs_binding_requirements.md
@@ -81,6 +81,9 @@ pointer to a `NODEJS_MODULE_CONFIG` object.
 **SRS_NODEJS_13_036: [** `NodeJS_Create` shall invoke `ModulesManager::AddModule` to add a new module to it's internal list. **]**
 
 **SRS_NODEJS_13_011: [** When the `NODEJS_MODULE_HANDLE_DATA::on_module_start` function is invoked, a new JavaScript object shall be created and added to the v8 global context with the name `gatewayHost`. The object shall implement the following interface (TypeScript syntax used below is just for the purpose of description):
+
+**SRS_NODEJS_27_046: [** `NodeJS_Create` shall block until the JS module has become fully initialized. **]**
+
 ```ts
 interface GatewayModuleHost {
     registerModule: (module: GatewayModule) => void;

--- a/bindings/nodejs/src/nodejs.cpp
+++ b/bindings/nodejs/src/nodejs.cpp
@@ -114,6 +114,7 @@ static MODULE_HANDLE NODEJS_Create(BROKER_HANDLE broker, const void* configurati
                 }
                 else
                 {
+                    /* Codes_SRS_NODEJS_27_046: [ `NodeJS_Create` shall block until the JS module has become fully initialized. ] */
                     // Wait for the module to become fully initialized
                     NodeModuleState module_state;
                     auto create_gate = handle_data->create_complete.get_future();


### PR DESCRIPTION
Test confirms that NODEJS_Create is synchronous, which is implicitly required by the current design of the IoT Field Gateway