### PR TITLE
Only remove links if they weren't already removed

### DIFF
--- a/core/src/gateway_internal.c
+++ b/core/src/gateway_internal.c
@@ -554,8 +554,13 @@ void gateway_removemodule_internal(GATEWAY_HANDLE_DATA* gateway_handle, MODULE_D
     remove_module_from_any_source(gateway_handle, *module_data_pptr);
     LINK_DATA *link;
     /* Codes_SRS_GATEWAY_26_018: [ This function shall remove any links that contain the removed module either as a source or sink. ] */
-    while ((link = VECTOR_find_if(gateway_handle->links, link_name_both_find, (*module_data_pptr)->module_name)) != NULL)
-        gateway_removelink_internal(gateway_handle, link);
+    if (gateway_handle->links)
+    {
+        while ((link = VECTOR_find_if(gateway_handle->links, link_name_both_find, (*module_data_pptr)->module_name)) != NULL)
+        {
+            gateway_removelink_internal(gateway_handle, link);
+        }
+    }
 
     free((*module_data_pptr)->module_name);
 

--- a/core/tests/gateway_createfromjson_ut/gateway_createfromjson_ut.cpp
+++ b/core/tests/gateway_createfromjson_ut/gateway_createfromjson_ut.cpp
@@ -980,14 +980,6 @@ TEST_FUNCTION(Gateway_Create_Start_fails_returns_null)
     STRICT_EXPECTED_CALL(mocks, VECTOR_erase(IGNORED_PTR_ARG,IGNORED_PTR_ARG, 1))
         .IgnoreArgument(1)
         .IgnoreArgument(2);
-    STRICT_EXPECTED_CALL(mocks, VECTOR_find_if(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .IgnoreArgument(1)
-        .IgnoreArgument(2)
-        .IgnoreArgument(3);
-    STRICT_EXPECTED_CALL(mocks, VECTOR_find_if(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .IgnoreArgument(1)
-        .IgnoreArgument(2)
-        .IgnoreArgument(3);
     STRICT_EXPECTED_CALL(mocks, Broker_RemoveModule(IGNORED_PTR_ARG,IGNORED_PTR_ARG))
         .IgnoreArgument(1)
         .IgnoreArgument(2);

--- a/core/tests/gateway_ut/gateway_ut.cpp
+++ b/core/tests/gateway_ut/gateway_ut.cpp
@@ -877,8 +877,6 @@ TEST_FUNCTION(Gateway_Create_VECTOR_push_back_Fails_To_Add_All_Modules_In_Props)
         .IgnoreArgument(1);
     STRICT_EXPECTED_CALL(mocks, VECTOR_front(IGNORED_PTR_ARG))
         .IgnoreArgument(1);
-    STRICT_EXPECTED_CALL(mocks, VECTOR_find_if(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .IgnoreAllArguments();
     EXPECTED_CALL(mocks, gballoc_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(mocks, Broker_RemoveModule(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreArgument(1)
@@ -1020,8 +1018,6 @@ TEST_FUNCTION(Gateway_Create_Broker_AddModule_Fails_To_Add_All_Modules_In_Props)
         .IgnoreArgument(1);
     STRICT_EXPECTED_CALL(mocks, VECTOR_front(IGNORED_PTR_ARG))
         .IgnoreArgument(1);
-    STRICT_EXPECTED_CALL(mocks, VECTOR_find_if(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .IgnoreAllArguments();
     STRICT_EXPECTED_CALL(mocks, Broker_RemoveModule(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreArgument(1)
         .IgnoreArgument(2);
@@ -1139,8 +1135,6 @@ TEST_FUNCTION(Gateway_Create_AddModule_WithDuplicatedModuleName_Fails)
         .IgnoreArgument(1);
     STRICT_EXPECTED_CALL(mocks, VECTOR_front(IGNORED_PTR_ARG))
         .IgnoreArgument(1);
-    STRICT_EXPECTED_CALL(mocks, VECTOR_find_if(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .IgnoreAllArguments();
     EXPECTED_CALL(mocks, gballoc_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(mocks, Broker_RemoveModule(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreArgument(1)
@@ -1519,8 +1513,6 @@ TEST_FUNCTION(Gateway_Create_Adds_All_Modules_And_Links_fromNonExistingModule_Fa
         .IgnoreArgument(1);
     STRICT_EXPECTED_CALL(mocks, VECTOR_front(IGNORED_PTR_ARG))
         .IgnoreArgument(1);
-    STRICT_EXPECTED_CALL(mocks, VECTOR_find_if(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .IgnoreAllArguments();
     STRICT_EXPECTED_CALL(mocks, Broker_RemoveModule(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreArgument(1)
         .IgnoreArgument(2);
@@ -1604,9 +1596,6 @@ TEST_FUNCTION(Gateway_Destroy_Continues_Unloading_If_Broker_RemoveModule_Fails)
         .IgnoreArgument(1); //Links
     STRICT_EXPECTED_CALL(mocks, VECTOR_front(IGNORED_PTR_ARG))
         .IgnoreArgument(1);
-    STRICT_EXPECTED_CALL(mocks, VECTOR_find_if(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .IgnoreAllArguments()
-        .ExpectedTimesExactly(2);
     EXPECTED_CALL(mocks, gballoc_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(mocks, Broker_RemoveModule(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreArgument(1)
@@ -1710,9 +1699,6 @@ TEST_FUNCTION(Gateway_Destroy_Removes_All_Modules_And_Destroys_Vector_Success)
         .IgnoreArgument(1);
     STRICT_EXPECTED_CALL(mocks, VECTOR_front(IGNORED_PTR_ARG))
         .IgnoreArgument(1);
-    STRICT_EXPECTED_CALL(mocks, VECTOR_find_if(IGNORED_PTR_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG))
-        .IgnoreAllArguments()
-        .ExpectedTimesExactly(2);
     EXPECTED_CALL(mocks, gballoc_free(IGNORED_PTR_ARG));
     STRICT_EXPECTED_CALL(mocks, Broker_RemoveModule(IGNORED_PTR_ARG, IGNORED_PTR_ARG))
         .IgnoreArgument(1)


### PR DESCRIPTION
In the course of investigating #86 I updated the submodule reference to azure-c-shared-utility locally and noticed new error spew in the console when running our gateway samples:
```
Error: Time:Tue Jan 31 18:10:21 2017 File:D:\tmp\azure-iot-gateway-sdk\deps\c-utility\src\vector.c Func:_VECTOR_size Line:328 invalid argument handle(NULL).
Error: Time:Tue Jan 31 18:10:21 2017 File:D:\tmp\azure-iot-gateway-sdk\deps\c-utility\src\vector.c Func:_VECTOR_find_if Line:291 invalid argument - handle(00000000), pred(50FB8280)
Error: Time:Tue Jan 31 18:10:21 2017 File:D:\tmp\azure-iot-gateway-sdk\deps\c-utility\src\vector.c Func:_VECTOR_size Line:328 invalid argument handle(NULL).
Error: Time:Tue Jan 31 18:10:21 2017 File:D:\tmp\azure-iot-gateway-sdk\deps\c-utility\src\vector.c Func:_VECTOR_find_if Line:291 invalid argument - handle(00000000), pred(50FB8280)
```
I discovered that these error messages were recently added to the VECTOR library. They are innocuous in this case, but they point to the fact that we're trying to remove links twice:

In `gateway_destroy_internal`, we loop through all the links and call `gateway_removelink_internal` for each one. Then we loop through all the modules and call `gateway_removemodule_internal` for each one. Inside `gateway_removemodule_internal`, we try to loop through all the links again and call `gateway_removelink_internal` *again* if the module we’re removing is listed either as the source or the sink for that link.

To fix this, I test for a NULL `links` VECTOR before entering the while loop that would try (in vain) to call `gateway_removelink_internal` a second time. I can't remove the while loop because the parent function (`gateway_removemodule_internal`) is called from a few other code paths as well; not all paths call `gateway_removelink_internal` twice. So the NULL test is a reasonable solution.