### PR TITLE
Clarify Microsoft.Azure.IoT.Gateway's public interface

### DIFF
--- a/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.IoT.Gateway/Broker.cs
+++ b/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.IoT.Gateway/Broker.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.IoT.Gateway
         /// <param name="broker">A reference to an existing broker.</param>
         /// <param name="module">A reference to an existing module.</param>
         /// <param name="nativeWrapper">A Native DotNet Core Host Wrapper used for Mocking purposes on Unit Tests.</param>
-        public Broker(IntPtr broker, IntPtr module, BrokerInterop brokerInterop)
+        internal Broker(IntPtr broker, IntPtr module, BrokerInterop brokerInterop)
         {
             /* Codes_SRS_DOTNET_CORE_BROKER_04_001: [ If broker is <= 0, Broker constructor shall throw a new ArgumentException ] */
             if (broker == IntPtr.Zero)
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.IoT.Gateway
         /// </summary>
         /// <param name="broker">A reference to an existing broker.</param>
         /// <param name="module">A reference to an existing module.</param>
-        public Broker(IntPtr broker, IntPtr module) : this(broker, module, new BrokerInterop())
+        internal Broker(IntPtr broker, IntPtr module) : this(broker, module, new BrokerInterop())
         {
 
         }

--- a/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.IoT.Gateway/BrokerInterop.cs
+++ b/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.IoT.Gateway/BrokerInterop.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.IoT.Gateway
     /// <summary>
     ///     Wrapper Used for Native/Managed Interop.
     /// </summary>
-    public class BrokerInterop
+    internal class BrokerInterop
     {
         /// <summary>
         ///      Module_DotNetCoreHost wrapper for publishing a message.

--- a/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.IoT.Gateway/DotNetCoreModuleInstance.cs
+++ b/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.IoT.Gateway/DotNetCoreModuleInstance.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.IoT.Gateway
     /// <summary>
     ///   Object that represents a .NET Core module instance.
     /// </summary>
-    public class DotNetCoreModuleInstance
+    internal class DotNetCoreModuleInstance
     {
         /// <summary>
         /// .NET Core module Instance.

--- a/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.IoT.Gateway/NetCoreInterop.cs
+++ b/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.IoT.Gateway/NetCoreInterop.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Microsoft.Azure.IoT.Gateway
 {
-    public class DotNetCoreReflectionLayer
+    internal class DotNetCoreReflectionLayer
     {
         virtual public Type GetType(string assemblyName, string entryType)
         {
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.IoT.Gateway
     ///    This class holds the static methods that are going to be called by the native .NET Core binding in order to create a module, receive message, destroy and start modules. 
     ///     It will use reflection to call the.NET Core managed module.
     /// </summary>
-    public class NetCoreInterop
+    internal class NetCoreInterop
     {
 
         private static NetCoreInteropInstance _netCoreInteropInstance = NetCoreInteropInstance.GetInstance();

--- a/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.IoT.Gateway/Properties/AssemblyInfo.cs
+++ b/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.IoT.Gateway/Properties/AssemblyInfo.cs
@@ -9,6 +9,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Microsoft.Azure.IoT.Gateway")]
 [assembly: AssemblyTrademark("")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+[assembly: InternalsVisibleTo("Microsoft.Azure.IoT.Gateway.Tests")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/tools/build_dotnet_core.cmd
+++ b/tools/build_dotnet_core.cmd
@@ -57,17 +57,17 @@ rem -- dotnet restore
 rem -----------------------------------------------------------------------------
 call dotnet restore %build-root%\bindings\dotnetcore\dotnet-core-binding\
 
-rem -----------------------------------------------------------------------------
-rem -- run Unit Tests
-rem -----------------------------------------------------------------------------
-call dotnet test %build-root%\bindings\dotnetcore\dotnet-core-binding\Microsoft.Azure.IoT.Gateway.Tests
-
-
 if %build-clean%==1 (
     call :clean-a-solution "%build-root%\bindings\dotnetcore\dotnet-core-binding\dotnet-core-binding.sln" %build-config% %build-platform%
     if not !errorlevel!==0 exit /b !errorlevel!
 )
 call :build-a-solution "%build-root%\bindings\dotnetcore\dotnet-core-binding\dotnet-core-binding.sln" %build-config% %build-platform%
+if not !errorlevel!==0 exit /b !errorlevel!
+
+rem -----------------------------------------------------------------------------
+rem -- run Unit Tests
+rem -----------------------------------------------------------------------------
+call dotnet test %build-root%\bindings\dotnetcore\dotnet-core-binding\Microsoft.Azure.IoT.Gateway.Tests
 if not !errorlevel!==0 exit /b !errorlevel!
 
 rem -----------------------------------------------------------------------------


### PR DESCRIPTION
- Mark implementation details as `internal`
- In build_dotnet_core.cmd, exit with an error if tests fail

I confirmed that unit tests pass and the sample still works.