### PR TITLE
Have iothub_writer.js stringify the message content for better display Issue #167

### DIFF
--- a/samples/nodejs_simple_sample/nodejs_modules/iothub_writer.js
+++ b/samples/nodejs_simple_sample/nodejs_modules/iothub_writer.js
@@ -50,7 +50,7 @@ class IotHubWriterModule
 
     receive(message) {
         if(this.connected) {
-            var m = new Message(message.content ? message.content.buffer : []);
+            var m = new Message(JSON.stringify(message.content));
             if(message.properties) {
                 for(var prop in message.properties) {
                     m.properties.add(prop, message.properties[prop]);


### PR DESCRIPTION
Stringify the message content coming into the iothub_writer, so that it's visible and readable on the device explorer.