### PR TITLE
Removing Unload Library when we Unload NodeJS Loader. It crashes node…

### DIFF
--- a/core/devdoc/node_loader_requirements.md
+++ b/core/devdoc/node_loader_requirements.md
@@ -106,8 +106,6 @@ Unloads the binding module from memory.
 
 **SRS_NODE_MODULE_LOADER_13_008: [** `NodeModuleLoader_Unload` shall do nothing if `moduleLibraryHandle` is `NULL`. **]**
 
-**SRS_NODE_MODULE_LOADER_13_009: [** `NodeModuleLoader_Unload` shall unload the binding module from memory by calling `DynamicLibrary_UnloadLibrary`. **]**
-
 **SRS_NODE_MODULE_LOADER_13_010: [** `NodeModuleLoader_Unload` shall free resources allocated when loading the binding module. **]**
 
 NodeModuleLoader_ParseEntrypointFromJson

--- a/core/src/module_loaders/node_loader.c
+++ b/core/src/module_loaders/node_loader.c
@@ -168,9 +168,6 @@ static void NodeModuleLoader_Unload(const MODULE_LOADER* loader, MODULE_LIBRARY_
     if (moduleLibraryHandle != NULL)
     {
         NODE_MODULE_HANDLE_DATA* loader_data = moduleLibraryHandle;
-        //Codes_SRS_NODE_MODULE_LOADER_13_009: [ NodeModuleLoader_Unload shall unload the binding module from memory by calling DynamicLibrary_UnloadLibrary. ]
-        DynamicLibrary_UnloadLibrary(loader_data->binding_module);
-
         //Codes_SRS_NODE_MODULE_LOADER_13_010: [ NodeModuleLoader_Unload shall free resources allocated when loading the binding module. ]
         free(loader_data);
     }

--- a/core/tests/node_loader_ut/node_loader_ut.c
+++ b/core/tests/node_loader_ut/node_loader_ut.c
@@ -628,7 +628,6 @@ TEST_FUNCTION(NodeModuleLoader_Unload_does_nothing_when_moduleLibraryHandle_is_N
     ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 }
 
-//Tests_SRS_NODE_MODULE_LOADER_13_009: [ NodeModuleLoader_Unload shall unload the binding module from memory by calling DynamicLibrary_UnloadLibrary. ]
 //Tests_SRS_NODE_MODULE_LOADER_13_010: [ NodeModuleLoader_Unload shall free resources allocated when loading the binding module. ]
 TEST_FUNCTION(NodeModuleLoader_Unload_frees_things)
 {
@@ -667,7 +666,6 @@ TEST_FUNCTION(NodeModuleLoader_Unload_frees_things)
 
     umock_c_reset_all_calls();
 
-    STRICT_EXPECTED_CALL(DynamicLibrary_UnloadLibrary((DYNAMIC_LIBRARY_HANDLE)0x42));
     STRICT_EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG))
         .IgnoreArgument(1);
 


### PR DESCRIPTION
… JS if we call Unload Library. Github Issue #161