### PR TITLE
Bump versions for 2017-04-27 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(azure_iot_gateway_sdk)
 
-set(GATEWAY_VERSION 1.0.4 CACHE INTERNAL "")
+set(GATEWAY_VERSION 1.0.5 CACHE INTERNAL "")
 set(COMPANY_NAME "Microsoft")
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 

--- a/bindings/dotnetcore/dotnet-core-binding/E2ETestModule/E2ETestModule.csproj
+++ b/bindings/dotnetcore/dotnet-core-binding/E2ETestModule/E2ETestModule.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-	<PackageVersion>1.0.2</PackageVersion>
+	<PackageVersion>1.0.3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.Devices.Gateway.Tests/Microsoft.Azure.Devices.Gateway.Tests.csproj
+++ b/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.Devices.Gateway.Tests/Microsoft.Azure.Devices.Gateway.Tests.csproj
@@ -8,7 +8,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
     <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
-	<PackageVersion>1.0.2</PackageVersion>
+	<PackageVersion>1.0.3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.Devices.Gateway/Microsoft.Azure.Devices.Gateway.csproj
+++ b/bindings/dotnetcore/dotnet-core-binding/Microsoft.Azure.Devices.Gateway/Microsoft.Azure.Devices.Gateway.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-	<PackageVersion>1.0.2</PackageVersion>
+	<PackageVersion>1.0.3</PackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/samples/dotnet_core_module_sample/modules/PrinterModule/PrinterModule.csproj
+++ b/samples/dotnet_core_module_sample/modules/PrinterModule/PrinterModule.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-	<PackageVersion>1.0.2</PackageVersion>
+	<PackageVersion>1.0.3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/dotnet_core_module_sample/modules/SensorModule/SensorModule.csproj
+++ b/samples/dotnet_core_module_sample/modules/SensorModule/SensorModule.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-	<PackageVersion>1.0.2</PackageVersion>
+	<PackageVersion>1.0.3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/docs/c/Doxyfile
+++ b/tools/docs/c/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Microsoft Azure IoT Gateway SDK"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.0.4
+PROJECT_NUMBER         = 1.0.5
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/tools/docs/dotnetcore/Doxyfile
+++ b/tools/docs/dotnetcore/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Microsoft Azure IoT Gateway SDK - .NET Core Binding"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.0.2
+PROJECT_NUMBER         = 1.0.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/tools/release/bump_version/versions.json
+++ b/tools/release/bump_version/versions.json
@@ -1,12 +1,12 @@
 {
     "gateway": 
     {
-        "core" : "1.0.4"
+        "core" : "1.0.5"
     },
     "bindings" :
     {
         "dotnet" : "1.0.2",
-        "dotnetcore": "1.0.2",
+        "dotnetcore": "1.0.3",
         "java" : "1.1.0"
     },
     "proxygateway" :


### PR DESCRIPTION
Code changes are limited to the core (which includes loaders, the native part of bindings, etc) and the .NET Core assembly (changed the target from netstandard16 to netstandard13).